### PR TITLE
update typing_extensions to 3.10.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "typing_extensions" %}
-{% set version = "3.10.0.0" %}
+{% set version = "3.10.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342
+  sha256: 49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,12 @@ outputs:
 
     requirements:
       host:
-        - python >=3.5
+        - python >=3.6
         - pip
         - setuptools
         - wheel
       run:
-        - python >=3.5
+        - python >=3.6
 
     test:
       imports:
@@ -53,20 +53,16 @@ about:
   license_file: LICENSE
   summary: Backported and Experimental Type Hints for Python
   description: |
-    The typing module was added to the standard library in Python 3.5 on a
-    provisional basis and will no longer be provisional in Python 3.7. However,
-    this means users of Python 3.5 - 3.6 who are unable to upgrade will not be
+    The typing module was added to the standard library in Python 3.5, but
+    many new features have been added to the module since then.
+    This means users of older Python versions who are unable to upgrade will not be
     able to take advantage of new types added to the typing module, such as
-    typing.Text or typing.Coroutine.
+    typing.Protocol or typing.TypedDict.
+    
+    The typing_extensions module contains backports of these changes.
+    Experimental types that will eventually be added to the ``typing``
+    module are also included in typing_extensions.
 
-    The typing_extensions module contains both backports of these changes
-    as well as experimental types that will eventually be added to the typing
-    module, such as Protocol.
-
-    Users of other Python versions should continue to install and use the
-    typing module from PyPi instead of using this one unless specifically
-    writing code that must be compatible with multiple Python versions or
-    requires experimental types.
   doc_url: https://github.com/python/typing
   dev_url: https://github.com/python/typing
 


### PR DESCRIPTION
1. verify the upstream
   there were some changes mentioned in the read me section. There are compatibility issues with python 3.5
    https://github.com/python/typing/blob/master/typing_extensions/README.rst
    This is mentioned in the Other Notes and Limitations section
2. check the pinnings
   - python 3.5 is no longer supported on the recipe
      https://github.com/python/typing/blob/master/typing_extensions/setup.cfg
3. the description was updated to match the new description on the upstream package
   since python 3.5 is no longer supported
4. verify the dev_url
5. verify the doc_url
6. verify that pip is checked
7. verify the test section
8. No issues found during testing
    the command used for testing was `conda-build typing_extensions --test`
    the result was the following `All tests passed`
    
    In order to test the `typing_extensions` package, the `bokeh` package was used.
    The meta.yaml file for the `bokeh` package was modified to use the `typing_extensions` version 3.10.0.2
    The package ....

Base on the results of the research, and based on the results of the research, and based on the results of the tests, we can conclude that it is safe to update the `typing_extensions` package.
