### PR TITLE
update to 4.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ outputs:
   - name: {{ name }}
     build:
       script: python -m pip install --no-deps --ignore-installed .
-      noarch: python
+      # noarch: python
 
     requirements:
       host:
@@ -33,9 +33,10 @@ outputs:
       imports:
         - typing_extensions
 
+
   - name: typing-extensions
     build:
-      noarch: python
+    # noarch: python
     requirements:
       run:
         - {{ pin_subpackage(name, exact=True) }}
@@ -48,7 +49,7 @@ outputs:
         - pip check
 
 about:
-  home: https://github.com/python/typing/tree/master/typing_extensions
+  home: https://github.com/python/typing_extensions
   license: PSF-2.0
   license_family: PSF
   license_file: LICENSE
@@ -64,8 +65,8 @@ about:
     Experimental types that will eventually be added to the ``typing``
     module are also included in typing_extensions.
 
-  doc_url: https://github.com/python/typing
-  dev_url: https://github.com/python/typing
+  doc_url: https://github.com/python/typing_extensions/README.md
+  dev_url: https://github.com/python/typing_extensions
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.1.1" %}
+{% set version = "4.3.0" %}
+{% set sha256 = "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42
+  sha256: {{ sha256 }}
 
 build:
   number: 0
+  skip: true  # [py<37]
 
 outputs:
   - name: {{ name }}
@@ -20,12 +22,12 @@ outputs:
 
     requirements:
       host:
-        - python >=3.6
+        - python
         - pip
         - setuptools
         - wheel
       run:
-        - python >=3.6
+        - python
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ about:
     Experimental types that will eventually be added to the ``typing``
     module are also included in typing_extensions.
 
-  doc_url: https://github.com/python/typing_extensions/README.md
+  doc_url: https://github.com/python/typing_extensions/blob/main/README.md
   dev_url: https://github.com/python/typing_extensions
 
 extra:


### PR DESCRIPTION
- updated version and sha
- added skip for python < 3.7, removed python bounds