### PR TITLE
add python dep to metapackage to ensure proper rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,10 @@ outputs:
     build:
     # noarch: python
     requirements:
+      host:
+        - python
       run:
+        - python
         - {{ pin_subpackage(name, exact=True) }}
     test:
       imports:


### PR DESCRIPTION
When I removed `noarch: python` from the metapackage output, I did not add a `python` dependency. As a result it did not get built for 3.8, 3.9, and 3.10; only 3.7. I'm going to let this rebuild and then copy over just the metapackages. For that reason I am not bumping the build.