### PR TITLE
typing_extensions 4.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.4.0" %}
-{% set sha256 = "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa" %}
+{% set version = "4.5.0" %}
+{% set sha256 = "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 89b8f1f..16832d6 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.4.0" %}
-{% set sha256 = "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa" %}
+{% set version = "4.5.0" %}
+{% set sha256 = "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb" %}
 
 package:
   name: {{ name|lower }}

```

**Jira ticket:** [PKG-844](https://anaconda.atlassian.net/browse/PKG-844) (typing_extensions-4.4.0)

**The upstream data:**
Github releases:  https://github.com/python/typing_extensions/releases
[Diff between the latest and previous upstream releases](https://github.com/python/typing_extensions/compare/4.4.0...4.5.0)
Changelog: https://github.com/python/typing_extensions/blob/main/CHANGELOG.md
Requirements:
 * pyproject.toml:  https://github.com/python/typing_extensions/blob/4.5.0/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 4.5.0
 * Release on PyPi:
    * version: 4.5.0
    * date: 2023-02-15T00:17:55
* [PyPi history](https://pypi.org/project/typing_extensions/#history)
 * Popularity: 
    * 3 months downloads: 5673877.0
    * All time:  23090218 downloads -  typing_extensions  4.4.0  Backported and Experimental Type Hints for Python  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family PSF is present
16. - [x] License: PSF-2.0
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|:-------------|
| PSF-2.0      |
</details>

**Check dependency issues:**

<details>
../aggregate/typing_extensions-feedstock/recipe/meta.yaml
Dependencies: ['flit-core 3.6.0', 'python', 'typing_extensions', 'flit-core >=3.6,<4', 'pip', 'setuptools', 'wheel']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 'NoneType' object has no attribute 'get'**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/typing_extensions-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/typing_extensions-feedstock/tree/4.5.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/typing_extensions)
* [Diff between upstream and feature branch](https://github.com/conda-forge/typing_extensions-feedstock/compare/main...AnacondaRecipes:4.5.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/typing_extensions-feedstock/compare/master...AnacondaRecipes:4.5.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/typing_extensions-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 4.5.0 git@github.com:AnacondaRecipes/typing_extensions-feedstock.git
```
