### PR TITLE
[PKG-1644] Update to 4.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ outputs:
         - wheel
       run:
         - python
-        - flit-core >=3.6,<4
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.4.0" %}
-{% set sha256 = "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa" %}
+{% set version = "4.5.0" %}
+{% set sha256 = "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ outputs:
     requirements:
       host:
         - python
-        - flit-core 3.6.0
+        - flit-core 3.8.0
         - pip
         - setuptools
         - wheel


### PR DESCRIPTION
Update to 4.5.0.

Package diff: https://github.com/python/typing_extensions/compare/4.4.0...4.5.0

I also updated `flit-core` to the latest version and removed it from the runtime dependencies since it's a build time only dependency.