### PR TITLE
Update to 4.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.7.1" %}
+{% set version = "4.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/typing_extensions-{{ version }}.tar.gz
-  sha256: b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
+  sha256: 23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<=37]
 
 outputs:
   - name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ outputs:
 
   - name: typing-extensions
     build:
+      noarch: python
     requirements:
       host:
         - python


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-3699) 
- [Upstream repository](https://github.com/python/typing_extensions/tree/4.9.0)
- [PyPi package inspector](https://inspector.pypi.io/project/typing-extensions/4.9.0/packages/0c/1d/eb26f5e75100d531d7399ae800814b069bc2ed2a7410834d57374d010d96/typing_extensions-4.9.0.tar.gz/)
- [Upstream changelog/diff](https://github.com/python/typing_extensions/blob/4.9.0/CHANGELOG.md)

### Explanation of changes:

- Straighforward version bump, apart from that upstream dropped support for python 3.7 (see changelog)
- Dependency for PyTorch 2.2
