### PR TITLE
PKG-3852: Build without noarch: python in the alias package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,6 @@ outputs:
 
   - name: typing-extensions
     build:
-      noarch: python
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<=37]
 
 outputs:


### PR DESCRIPTION
v4.9.0 build number 1

**Destination channel:** defaults

### Links

- [PKG-3852](https://anaconda.atlassian.net/browse/PKG-3852) 

### Explanation of changes:

- Remove noarch: python because the metapackage is pinned exactly to the base package. Because the base package doesn't use noarch: python, there's nothing that satisfies this exact pinning, and the metapackage is never used.


[PKG-3852]: https://anaconda.atlassian.net/browse/PKG-3852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ