### PR TITLE
typing_extensions 4.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<=38]
+  skip: true  # [py<38]
 
 outputs:
   - name: {{ name }}
@@ -58,7 +58,7 @@ about:
     This means users of older Python versions who are unable to upgrade will not be
     able to take advantage of new types added to the typing module, such as
     typing.Protocol or typing.TypedDict.
-    
+
     The typing_extensions module contains backports of these changes.
     Experimental types that will eventually be added to the ``typing``
     module are also included in typing_extensions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0
 
 build:
-  number: 1
-  skip: true  # [py<=37]
+  number: 0
+  skip: true  # [py<=38]
 
 outputs:
   - name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.9.0" %}
+{% set version = "4.11.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/typing_extensions-{{ version }}.tar.gz
-  sha256: 23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783
+  sha256: 83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0
 
 build:
   number: 1


### PR DESCRIPTION
typing_extensions 4.11.0

**Destination channel:** defaults

### Links

- [PKG-4738](https://anaconda.atlassian.net/browse/PKG-4738)
- [Upstream repository](https://github.com/python/typing_extensions/tree/4.11.0)
- [Upstream changelog/diff](https://github.com/python/typing_extensions/releases)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/typeguard-feedstock/pull/3
  - https://github.com/AnacondaRecipes/ydata-profiling-feedstock/pull/4

### Explanation of changes:

- Update version
- Update python version skip
- Linter fixes

[PKG-4738]: https://anaconda.atlassian.net/browse/PKG-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ