### PR TITLE
typing_extensions 4.12.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.11.0" %}
+{% set version = "4.12.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/typing_extensions-{{ version }}.tar.gz
-  sha256: 83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0
+  sha256: 1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
 
 build:
   number: 0


### PR DESCRIPTION
typing-extensions 4.12.2

**Destination channel:** {defaults}

### Links

- [PKG-6541](https://anaconda.atlassian.net/browse/PKG-6541) 
- [Upstream repository](https://github.com/python/typing_extensions)
- [Upstream changelog/diff](https://github.com/python/typing_extensions/blob/4.12.2/CHANGELOG.md)
- Relevant dependency PRs:
  - [`typing-extensions 4.12.2`](https://github.com/AnacondaRecipes/typing_extensions-feedstock/pull/20)
  - [`pydantic-core 2.27.1`](https://github.com/AnacondaRecipes/pydantic-core-feedstock/pull/7)
  - [`pydantic 2.10.3`](url)
  - [`menuinst 2.2.0`](url) with py3.13 support for `conda`

### Explanation of changes:

- ...


[PKG-6541]: https://anaconda.atlassian.net/browse/PKG-6541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ