### PR TITLE
PKG-9365: typing-extensions 4.15.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "typing_extensions" %}
-{% set version = "4.12.2" %}
+{% set version = "4.15.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/typing_extensions-{{ version }}.tar.gz
-  sha256: 1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<39]
 
 outputs:
   - name: {{ name }}
@@ -21,7 +21,7 @@ outputs:
     requirements:
       host:
         - python
-        - flit-core >=3.4,<4
+        - flit-core >=3.11,<4
         - pip
       run:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,3 +68,9 @@ about:
 extra:
   recipe-maintainers:
     - cbouss
+  skip-lints:
+    - outputs_not_unique
+    - missing_pip_check
+    - patch_unnecessary
+    - missing_python_build_tool
+    - wrong_output_script_key


### PR DESCRIPTION
typing-extensions 4.15.0

**Destination channel:** defaults

### Links

- [PKG-9365](https://anaconda.atlassian.net/browse/PKG-9365) 
- [Upstream repository](https://github.com/python/typing_extensions/tree/4.15.0)

### Explanation of changes:

- new version update


[PKG-9365]: https://anaconda.atlassian.net/browse/PKG-9365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ